### PR TITLE
Prod configs

### DIFF
--- a/backends/api/.dockerignore
+++ b/backends/api/.dockerignore
@@ -2,3 +2,4 @@ node_modules
 .dockerignore
 Dockerfile
 .gitignore
+src/generated

--- a/backends/api/.gitignore
+++ b/backends/api/.gitignore
@@ -2,4 +2,4 @@ node_modules
 # Keep environment variables out of version control
 .env
 
-/generated/prisma
+src/generated

--- a/backends/api/Dockerfile
+++ b/backends/api/Dockerfile
@@ -5,15 +5,15 @@ WORKDIR /app
 COPY package*.json .
 RUN npm ci
 COPY . .
-RUN npx prisma generate
 
 FROM base AS builder
-RUN npm run build
 RUN npx prisma generate
+RUN npm run build
 
 FROM node:22.20.0-alpine3.21 AS runtime
 WORKDIR /app
 COPY --from=builder /app/dist .
+COPY --from=builder /app/src/generated/libquery_engine-linux-musl-openssl-3.0.x.so.node /app/generated
 COPY package*.json .
 COPY prisma .
 RUN npm ci --omit=dev

--- a/backends/api/prisma/schema.prisma
+++ b/backends/api/prisma/schema.prisma
@@ -5,7 +5,9 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider = "prisma-client"
+  output   = "../src/generated"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {

--- a/backends/api/src/app.ts
+++ b/backends/api/src/app.ts
@@ -13,7 +13,7 @@ app.use(express.json());
 app.use(passport.initialize());
 app.use(requestLogging);
 
-app.use("/users", usersRouter);
-app.use("/logbooks", requireAuth, logbookRouter);
+app.use("/api/users", usersRouter);
+app.use("/api/logbooks", requireAuth, logbookRouter);
 
 export default app;

--- a/backends/api/src/app.ts
+++ b/backends/api/src/app.ts
@@ -13,7 +13,7 @@ app.use(express.json());
 app.use(passport.initialize());
 app.use(requestLogging);
 
-app.use("/api/users", usersRouter);
-app.use("/api/logbooks", requireAuth, logbookRouter);
+app.use("/users", usersRouter);
+app.use("/logbooks", requireAuth, logbookRouter);
 
 export default app;

--- a/backends/api/src/configs/db.ts
+++ b/backends/api/src/configs/db.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "../generated/client.ts";
 
 const prisma = new PrismaClient();
 

--- a/backends/api/src/types/logbook.ts
+++ b/backends/api/src/types/logbook.ts
@@ -1,1 +1,1 @@
-export type { Logbook } from "@prisma/client";
+export type { Logbook } from '../generated/client.ts';

--- a/backends/api/src/types/logitem.ts
+++ b/backends/api/src/types/logitem.ts
@@ -1,1 +1,1 @@
-export type { Logitem } from "@prisma/client";
+export type { Logitem } from '../generated/client.ts';

--- a/backends/api/src/types/user.ts
+++ b/backends/api/src/types/user.ts
@@ -1,1 +1,1 @@
-export type { User } from "@prisma/client";
+export type { User } from '../generated/client.ts';

--- a/backends/api/src/utils/prismaErrorHandler.ts
+++ b/backends/api/src/utils/prismaErrorHandler.ts
@@ -1,7 +1,14 @@
-import { Prisma } from "@prisma/client";
+import { Prisma } from "../generated/client.ts";
 import logger from "./logger.ts";
 import type { ResultFailure } from "../types/result.ts";
 
+/**
+ *
+ *
+ * @param {unknown} error
+ * @param {ResultFailure} result
+ * @return {*}  {Promise<ResultFailure>}
+ */
 const handlerPrismaError = async (
   error: unknown,
   result: ResultFailure,

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -9,10 +9,18 @@ services:
       - ./backends/api/prisma:/app/prisma
     ports:
       - ${API_PORT}:${API_PORT}
+    labels:
+      - "traefik.http.routers.api.entrypoints=web"
 
   db:
     ports:
       - ${POSTGRES_PORT}:${POSTGRES_PORT}
+  
+  web:
+    ports:
+      - "5173:80"
+    labels:
+      - "traefik.http.routers.web.entrypoints=web"
   
   traefik:
     command:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -13,3 +13,10 @@ services:
   db:
     ports:
       - ${POSTGRES_PORT}:${POSTGRES_PORT}
+  
+  traefik:
+    command:
+      - "--api.insecure=true"
+      - "--api.dashboard=true"
+    ports:
+      - "8080:8080"

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,6 +1,30 @@
 services:
   api:
     restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api-router.entrypoints=web"
+      - "traefik.http.routers.api-router.rule=PathPrefix(`/api`)"
+      - "traefik.http.services.api-service.loadbalancer.server.port=8000"
 
   db:
     restart: always
+
+  web:
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web-router.entrypoints=web"
+      - "traefik.http.routers.web-router.rule=PathPrefix(`/`)"
+      - "traefik.http.services.web-service.loadbalancer.server.port=80"
+
+  traefik:
+    image: traefik:v3
+    restart: always
+    command:
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:8000"
+    ports:
+      - "8000:8000"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,8 +2,9 @@ services:
   api:
     restart: always
     labels:
-      - "traefik.http.routers.api-router.rule=Host(`${HOST}`)"
-      - "traefik.http.routers.api-router.tls=true"
+      - "traefik.http.routers.api.rule=Host(`api.${HOST}`)"
+      - "traefik.http.routers.api.entrypoints=websecure"
+      - "traefik.http.routers.api.tls=true"
 
   db:
     restart: always
@@ -11,8 +12,9 @@ services:
   web:
     restart: always
     labels:
-      - "traefik.http.routers.web-router.rule=Host(`${HOST}`)"
-      - "traefik.http.routers.web-router.tls=true"
+      - "traefik.http.routers.web.rule=Host(`${HOST}`)"
+      - "traefik.http.routers.web.entrypoints=websecure"
+      - "traefik.http.routers.web.tls=true"
   
   traefik:
     restart: always
@@ -22,8 +24,16 @@ services:
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
       - "--entrypoints.websecure.address=:443"
       - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
-      - "--certificatesresolvers.letsencrypt.acme.storage=acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme.json"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
       - "--entrypoints.websecure.http.tls.certresolver=letsencrypt"
+      - "--log.filePath=/var/log/traefik/logs.log"
+      - "--log.format=json"
+      - "--log.level=INFO"
+      - "--log.maxAge=30"
+      - "--accesslog=true"
+      - "--accesslog.format=json"
     ports:
       - "443:443"
+    volumes:
+      - /etc/traefik/acme.json:/etc/traefik/acme.json

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,10 +2,8 @@ services:
   api:
     restart: always
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api-router.entrypoints=web"
-      - "traefik.http.routers.api-router.rule=PathPrefix(`/api`)"
-      - "traefik.http.services.api-service.loadbalancer.server.port=8000"
+      - "traefik.http.routers.api-router.rule=Host(`${HOST}`)"
+      - "traefik.http.routers.api-router.tls=true"
 
   db:
     restart: always
@@ -13,18 +11,19 @@ services:
   web:
     restart: always
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.web-router.entrypoints=web"
-      - "traefik.http.routers.web-router.rule=PathPrefix(`/`)"
-      - "traefik.http.services.web-service.loadbalancer.server.port=80"
-
+      - "traefik.http.routers.web-router.rule=Host(`${HOST}`)"
+      - "traefik.http.routers.web-router.tls=true"
+  
   traefik:
-    image: traefik:v3
     restart: always
     command:
-      - "--providers.docker=true"
-      - "--entrypoints.web.address=:8000"
+      - "--providers.docker.exposedByDefault=false"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--entrypoints.websecure.http.tls.certresolver=letsencrypt"
     ports:
-      - "8000:8000"
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "443:443"

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,11 @@ services:
         condition: service_healthy
     env_file:
       - ${ENV_FILE}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api-router.entrypoints=web"
+      - "traefik.http.routers.api-router.rule=PathPrefix(`/api`)"
+      - "traefik.http.services.api-service.loadbalancer.server.port=8000"
 
   db:
     image: postgres:${POSTGRES_VERSION}-alpine
@@ -28,6 +33,22 @@ services:
   web:
     restart: unless-stopped
     build: ./web
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web-router.entrypoints=web"
+      - "traefik.http.routers.web-router.rule=PathPrefix(`/`)"
+      - "traefik.http.services.web-service.loadbalancer.server.port=80"
+
+  traefik:
+    image: traefik:v3
+    restart: unless-stopped
+    command: 
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "80:80"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
 volumes:
   postgres_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,5 +25,9 @@ services:
       retries: 5
       start_period: 30s
 
+  web:
+    restart: unless-stopped
+    build: ./web
+
 volumes:
   postgres_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,9 +12,8 @@ services:
       - ${ENV_FILE}
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.api-router.entrypoints=web"
-      - "traefik.http.routers.api-router.rule=PathPrefix(`/api`)"
-      - "traefik.http.services.api-service.loadbalancer.server.port=8000"
+      - "traefik.http.routers.api.rule=PathPrefix(`/`)"
+      - "traefik.http.services.api.loadbalancer.server.port=8000"
 
   db:
     image: postgres:${POSTGRES_VERSION}-alpine
@@ -35,9 +34,8 @@ services:
     build: ./web
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.web-router.entrypoints=web"
-      - "traefik.http.routers.web-router.rule=PathPrefix(`/`)"
-      - "traefik.http.services.web-service.loadbalancer.server.port=80"
+      - "traefik.http.routers.web.rule=PathPrefix(`/`)"
+      - "traefik.http.services.web.loadbalancer.server.port=80"
 
   traefik:
     image: traefik:v3

--- a/dev.env
+++ b/dev.env
@@ -1,3 +1,6 @@
+HOST=localhost
+ACME_EMAIL=your-email@example.com
+
 DEVELOP=true
 LOG_LEVEL=debug
 API_PORT=8000

--- a/dev.env
+++ b/dev.env
@@ -2,7 +2,6 @@ HOST=localhost
 ACME_EMAIL=your-email@example.com
 
 DEVELOP=true
-LOG_LEVEL=debug
 API_PORT=8000
 JWT_SECRET=secret
 ACCESS_EXPIRES=

--- a/load.env
+++ b/load.env
@@ -5,7 +5,12 @@ source $ENV_FILE
 set +a
 
 alias run-setup="sh setup.sh"
+
 alias run-dev="docker compose -f compose.yaml -f compose.dev.yaml up --build"
 alias dev-down="docker compose -f compose.yaml -f compose.dev.yaml down"
-alias run-prod="docker compose -f compose.yaml -f compose.prod.yaml up --build"
+alias dev-sh="docker compose -f compose.yaml -f compose.dev.yaml run --rm api sh"
 alias migrate-dev="docker compose -f compose.yaml -f compose.dev.yaml run --rm api npx prisma migrate dev && run-setup"
+
+alias prod-down="docker compose -f compose.yaml -f compose.prod.yaml down"
+alias prod-sh="docker compose -f compose.yaml -f compose.prod.yaml run --rm api sh"
+alias run-prod="docker compose -f compose.yaml -f compose.prod.yaml up --build"

--- a/mobile/Dockerfile
+++ b/mobile/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:22.20.0-alpine3.21
-WORKDIR /app
-COPY package*.json .
-RUN npm ci
-COPY . .
-CMD ["npm", "run", "start"]

--- a/setup.sh
+++ b/setup.sh
@@ -1,1 +1,1 @@
-cd backends/api && npm i && npx prisma generate && ../../mobile && npm i
+cd backends/api && npm i && npx prisma generate

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22.20.0-alpine3.21 AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci
+COPY . .
+
+FROM base AS builder
+RUN npm run build
+
+FROM nginx:alpine AS server
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY --from=builder /app/dist /usr/share/nginx/html

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -10,6 +10,9 @@ http {
     server {
         listen 80;
 
+        include /etc/nginx/mime.types; 
+        default_type application/octet-stream;
+
         root /usr/share/nginx/html;
         index index.html;
 

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,20 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+    use epoll;
+    multi_accept on;
+}
+
+http {
+    server {
+        listen 80;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
Adds configurations/reconfigurations for prod deployment.
- Fixed prisma configuration (only previously worked with development conifg)
  - No longer uses js based prisma client
- Traefik configured as reverse-proxy
- TLS/SSL configurations
- Dockerfile and Nginx configuration for web frontend
  - This will currently break the docker setup unless you add a Vite + React project in the /web folder