### PR TITLE
Vessel api fix

### DIFF
--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -113,19 +113,19 @@ export default function Profile() {
 			<View style={styles.menu}>
 				<Button title="Add New Vessel" onPress={() => setAddVesselOpen(true)} style={styles.menuItem} />
 				<Button
-					title="Get vessels from db"
+					title="Get vessels from server"
 					onPress={() => syncVesselsMutation.mutate()}
 					loading={syncVesselsMutation.isPending}
 					style={styles.menuItem}
 				/>
 				{user && (
 					<Button
-						title="Upload Offline Data"
+						title="Get vessels from phone"
 						onPress={() => mergeMutation.mutate()}
 						//isLoading={mergeMutation.isPending}
 					/>
 				)}
-				<Button title="Edit home buttons" onPress={() => setEditButtonsOpen(true)} style={styles.menuItem} variant="outline" />
+				<Button title="Edit homescreen buttons" onPress={() => setEditButtonsOpen(true)} style={styles.menuItem} variant="outline" />
 			</View>
 
 			{/* --- Modal: Vessel List --- */}

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -57,7 +57,8 @@ export default function Profile() {
 	const [newButtonLabel, setNewButtonLabel] = useState("");
 
 	const handleLogout = async () => {
-		await logout();
+		logout();
+		setCurrentLogbook(null);
 		router.replace("/");
 	};
 

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -19,7 +19,13 @@ import { Button } from "@/src/components/Button";
 import { Input } from "@/src/components/Input";
 import { Card } from "@/src/components/Card";
 import { useOwnTheme } from "@/src/context/ThemeContext";
-import { useVessels, useAddVessel, useDeleteVessel, useSyncVessels } from "@/src/features/logbooks/hooks";
+import {
+	useVessels,
+	useAddVessel,
+	useDeleteVessel,
+	useSyncVessels,
+	useMergeLocalData
+} from "@/src/features/logbooks/hooks";
 import { useAuthStore } from "@/src/store/authStore";
 import { useLogbookStore } from "@/src/store/logbookStore";
 import { useButtonStore } from "@/src/store/buttonStore";
@@ -39,6 +45,7 @@ export default function Profile() {
 	const addVesselMutation = useAddVessel();
 	const deleteVesselMutation = useDeleteVessel();
 	const syncVesselsMutation = useSyncVessels();
+	const mergeMutation = useMergeLocalData();
 
 	// UI State
 	const [isVesselListOpen, setVesselListOpen] = useState(false);
@@ -110,6 +117,13 @@ export default function Profile() {
 					loading={syncVesselsMutation.isPending}
 					style={styles.menuItem}
 				/>
+				{user && (
+					<Button
+						title="Upload Offline Data"
+						onPress={() => mergeMutation.mutate()}
+						//isLoading={mergeMutation.isPending}
+					/>
+				)}
 				<Button title="Edit home buttons" onPress={() => setEditButtonsOpen(true)} style={styles.menuItem} variant="outline" />
 			</View>
 

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -132,6 +132,7 @@ export default function Profile() {
 				<View style={styles.modalOverlay}>
 					<View style={[styles.modalContent, { backgroundColor: theme.colors.background, borderColor: theme.colors.surface }]}>
 						<Text style={[styles.modalTitle, { color: theme.colors.textPrimary }]}>Select Vessel</Text>
+						<Text style={[styles.longPressHint, { color: theme.colors.textSecondary }]}>Long press to delete</Text>
 
 						{/* List Content */}
 						<FlatList
@@ -140,21 +141,36 @@ export default function Profile() {
 							style={{ maxHeight: 300, width: "100%", marginBottom: 10 }}
 							renderItem={({ item }) => (
 								<TouchableOpacity
-									style={styles.vesselItem}
+									style={[styles.vesselCard, { backgroundColor: theme.colors.background }]}
 									onPress={() => {
 										setCurrentLogbook({ id: item.id, name: item.name });
 										setVesselListOpen(false);
 									}}
+									onLongPress={() => {
+										Alert.alert(
+											"Delete Vessel",
+											`Are you sure you want to permanently delete "${item.name}"?`,
+											[
+												{ text: "Cancel", style: "cancel" },
+												{
+													text: "Delete",
+													style: "destructive",
+													onPress: () => handleDeleteVessel(item.id)
+												}
+											]
+										);
+									}}
+									delayLongPress={500}
 								>
-									<Text style={{ color: theme.colors.textPrimary, fontSize: 18 }}>{item.name}</Text>
-
-									{/* DELETE BUTTON - Styled to match Logout */}
-									<TouchableOpacity
-										onPress={() => handleDeleteVessel(item.id)}
-										style={[styles.deleteBtn, { backgroundColor: theme.colors.danger }]}
-									>
-										<Text style={styles.btnTextWhite}>Delete</Text>
-									</TouchableOpacity>
+									<View style={{ flex: 1 }}>
+										<Text
+											style={[styles.vesselName, { color: theme.colors.textPrimary }]}
+											numberOfLines={1}
+											ellipsizeMode="tail"
+										>
+											{item.name}
+										</Text>
+									</View>
 								</TouchableOpacity>
 							)}
 						/>
@@ -346,7 +362,7 @@ const styles = StyleSheet.create({
 	modalTitle: {
 		fontSize: 22,
 		fontWeight: "bold",
-		marginBottom: 20,
+		marginBottom: 5,
 		textAlign: "center",
 	},
 	modalActions: {
@@ -412,5 +428,19 @@ const styles = StyleSheet.create({
 		alignItems: "center",
 		paddingHorizontal: 20,
 		borderRadius: 10,
+	},
+	sectionHeader: {
+		marginBottom: 10,
+	},
+	longPressHint: {
+		fontSize: 12,
+		textAlign: "center",
+	},
+	vesselCard: {
+		padding: 20,
+		borderBottomWidth: 1,
+		borderColor: '#eee',
+		flexDirection: 'row',
+		alignItems: 'center',
 	},
 });

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider, useOwnTheme } from "@/src/context/ThemeContext";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { SQLiteProvider } from "expo-sqlite";
 import { migrateDbIfNeeded } from "@/src/database/db";
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -13,11 +13,6 @@ function RootLayoutContent() {
     const { theme } = useOwnTheme();
     return (
         <SafeAreaProvider>
-            {/* The Screen component handles SafeArea per page, but we keep this top-level
-                provider for context. We remove the direct SafeAreaView wrapper here to
-                avoid double-padding, or you can keep it if you prefer global padding.
-                For this refactor, let's keep it minimal so pages have full control.
-             */}
             <Stack
                 screenOptions={{
                     headerShown: false,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
+    "baseline-browser-mapping": "^2.10.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
     "typescript": "~5.9.2"

--- a/mobile/src/database/db.ts
+++ b/mobile/src/database/db.ts
@@ -132,12 +132,13 @@ export async function deleteLogItem(db: SQLiteDatabase, id: string): Promise<voi
  * @param registration - The registration number of the vessel (retained locally)
  * @returns The definitive ID of the created record
  */
-export async function addLogbook(db: SQLiteDatabase, name: string, type: string, registration: string): Promise<string> {
+export async function addLogbook(db: SQLiteDatabase,ownerId: string, name: string, type: string, registration: string): Promise<string> {
 	const id = uuidv4();
 	const now = new Date().toISOString();
 	await db.runAsync(
-		`INSERT INTO logbooks (id, name, type, registration, created_at, updated_at, version) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO logbooks (id, owner_id, name, type, registration, created_at, updated_at, version) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		id,
+		ownerId,
 		name,
 		type,
 		registration,
@@ -148,8 +149,8 @@ export async function addLogbook(db: SQLiteDatabase, name: string, type: string,
 	return id;
 }
 
-export async function getLogbooks(db: SQLiteDatabase): Promise<DBLogbook[]> {
-	return db.getAllAsync<DBLogbook>(`SELECT * FROM logbooks ORDER BY created_at DESC`);
+export async function getLogbooks(db: SQLiteDatabase, ownerId: string): Promise<DBLogbook[]> {
+	return db.getAllAsync<DBLogbook>(`SELECT * FROM logbooks WHERE owner_id = ? ORDER BY created_at DESC`, ownerId);
 }
 
 export async function deleteLogbook(db: SQLiteDatabase, id: string): Promise<void> {
@@ -163,7 +164,7 @@ export async function deleteLogbook(db: SQLiteDatabase, id: string): Promise<voi
  * @param db - The active SQLite database context
  * @param remoteLogbooks - The array of logbook DTOs returned from the Express API
  */
-export async function syncLogbooks(db: SQLiteDatabase, remoteLogbooks: any[]): Promise<void> {
+export async function syncLogbooks(db: SQLiteDatabase, remoteLogbooks: any[], ownerId: string): Promise<void> {
 	for (const lb of remoteLogbooks) {
 		// Prisma returns 'vesselType' and 'registration', map them, falling back to empty strings if null.
 		const name = lb.name || "Unnamed Vessel";
@@ -176,9 +177,10 @@ export async function syncLogbooks(db: SQLiteDatabase, remoteLogbooks: any[]): P
 		const version = lb.version || 0;
 
 		await db.runAsync(
-			`INSERT OR IGNORE INTO logbooks (id, name, type, registration, created_at, updated_at, version)
-             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			`INSERT OR IGNORE INTO logbooks (id, owner_id, name, type, registration, created_at, updated_at, version)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 			lb.id,
+			ownerId,
 			name,
 			type,
 			registration,
@@ -187,4 +189,19 @@ export async function syncLogbooks(db: SQLiteDatabase, remoteLogbooks: any[]): P
 			version,
 		);
 	}
+}
+
+// --- MIGRATION FUNCTION ---
+
+/**
+ * Takes any vessel currently marked as 'local' (offline user)
+ * Re-assigns it to the newly logged-in user
+ */
+export async function assignLocalDataToUser(db: SQLiteDatabase, userId: string): Promise<number> {
+	const result = await db.runAsync(
+		`UPDATE logbooks SET owner_id = ? WHERE owner_id = 'local' OR owner_id IS NULL`,
+		userId
+	);
+	// Returns the number of vessels that were moved to the new account
+	return result.changes;
 }

--- a/mobile/src/features/logbook/hooks.ts
+++ b/mobile/src/features/logbook/hooks.ts
@@ -1,6 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSQLiteContext } from "expo-sqlite";
 import { getLogItems, addLogItem, deleteLogItem, updateLogItem, getLogItemById } from "@/src/database/db";
+import { pushRemoteLogItems, deleteRemoteLogItems, updateRemoteLogItems } from "@/src/utils/api";
+import { useAuthStore } from "@/src/store/authStore";
 
 export const LOG_ITEM_KEYS = {
 	all: ["log_items"] as const,
@@ -28,10 +30,24 @@ export function useLogItem(id: string) {
 export function useAddLogItem() {
 	const db = useSQLiteContext();
 	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
 
 	return useMutation({
 		mutationFn: async (data: { title: string; body?: string | null; lat: number; lon: number; logbookId: string }) => {
-			return addLogItem(db, data.logbookId, data.title, data.body || null, data.lat, data.lon);
+			const localId = await addLogItem(db, data.logbookId, data.title, data.body || null, data.lat, data.lon);
+
+			if (user?.id) {
+				const newItem = await getLogItemById(db, localId);
+				if (newItem) {
+					pushRemoteLogItems(data.logbookId, [newItem])
+						.then((res) => console.log(`Server saved ${res.count} items.`))
+						.catch((err) => {
+							console.log("Pin saved locally and will sync later.", err.message);
+					});
+				}
+			}
+
+			return localId;
 		},
 		onSuccess: () => {
 			// Automatically refresh the list when a log is added
@@ -43,10 +59,24 @@ export function useAddLogItem() {
 export function useUpdateLogItem() {
 	const db = useSQLiteContext();
 	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
 
 	return useMutation({
-		mutationFn: async (data: { id: string; title: string; body?: string | null; lat?: number; lon?: number }) => {
-			return updateLogItem(db, data.id, data.title, data.body || null, data.lat, data.lon);
+		mutationFn: async (data: { id: string; title: string; body?: string | null; lat?: number; lon?: number; logbookId: string }) => {
+			await updateLogItem(db, data.id, data.title, data.body || null, data.lat, data.lon);
+
+			if (user?.id) {
+				const updatedItem = await getLogItemById(db, data.id);
+				if (updatedItem) {
+					updateRemoteLogItems(data.logbookId, [updatedItem])
+						.then(() => console.log("Success! Edit uploaded to server."))
+						.catch((err) => {
+							console.log("Device offline. Pin edit saved locally and will sync later.", err.message);
+						});
+				}
+			}
+
+			return data.id;
 		},
 		onSuccess: (_, variables) => {
 			queryClient.invalidateQueries({ queryKey: LOG_ITEM_KEYS.all }).then();
@@ -58,10 +88,20 @@ export function useUpdateLogItem() {
 export function useDeleteLogItem() {
 	const db = useSQLiteContext();
 	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
 
 	return useMutation({
-		mutationFn: async (id: string) => {
-			return deleteLogItem(db, id);
+		mutationFn: async (data: {id: string, logbookId: string}) => {
+			await deleteLogItem(db, data.id);
+
+			// If logged in, tell the server to delete it
+			if (user?.id) {
+				deleteRemoteLogItems(data.logbookId, [data.id]).catch((err) => {
+					console.log("Device offline. Deletion will need to be reconciled later.", err.message);
+				});
+			}
+
+			return data.id;
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: LOG_ITEM_KEYS.all });

--- a/mobile/src/features/logbooks/hooks.ts
+++ b/mobile/src/features/logbooks/hooks.ts
@@ -1,38 +1,49 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Alert } from "react-native";
 import { useSQLiteContext } from "expo-sqlite";
-import { getLogbooks, addLogbook, deleteLogbook, syncLogbooks } from "@/src/database/db";
+import { getLogbooks, addLogbook, deleteLogbook, syncLogbooks, assignLocalDataToUser } from "@/src/database/db";
 import { createRemoteLogbook, deleteRemoteLogbook, fetchRemoteLogbooks } from "@/src/utils/api";
+import { useAuthStore } from "@/src/store/authStore";
 
 export const LOGBOOK_KEYS = {
-	all: ["logbooks"] as const,
+	all: (ownerId: string) => ["logbooks", ownerId] as const,
 };
 
 export function useVessels() {
 	const db = useSQLiteContext();
+	const user = useAuthStore((state) => state.user);
+	const ownerId = user?.id || "local";
+
 	return useQuery({
-		queryKey: LOGBOOK_KEYS.all,
-		queryFn: () => getLogbooks(db),
+		queryKey: LOGBOOK_KEYS.all(ownerId),
+		queryFn: () => getLogbooks(db, ownerId),
 	});
 }
 
 export function useAddVessel() {
 	const db = useSQLiteContext();
 	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
+
+	const ownerId = user?.id || "local";
 
 	return useMutation({
 		mutationFn: async (data: { name: string; type: string; registration: string }) => {
-			const localId = await addLogbook(db, data.name, data.type, data.registration);
+			const localId = await addLogbook(db, ownerId, data.name, data.type, data.registration);
 
 			// Push to backend
-			createRemoteLogbook(localId, data.name, data.type, data.registration).catch((err) => {
-				console.log("Device offline or sync failed. Vessel saved locally and will sync later.", err.message);
-			});
+			if(user?.id){
+				createRemoteLogbook(localId, data.name, data.type, data.registration).catch((err) => {
+					console.log("Device offline or sync failed. Vessel saved locally and will sync later.", err.message);
+				});
+			} else {
+				console.log("Offline mode active: Vessel saved to local device storage");
+			}
 
 			return localId;
 		},
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: LOGBOOK_KEYS.all });
+			queryClient.invalidateQueries({ queryKey: LOGBOOK_KEYS.all(ownerId) });
 		},
 	});
 }
@@ -40,19 +51,24 @@ export function useAddVessel() {
 export function useDeleteVessel() {
 	const db = useSQLiteContext();
 	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
+
+	const ownerId = user?.id || "local";
 
 	return useMutation({
 		mutationFn: async (id: string) => {
 			await deleteLogbook(db, id);
 
-			deleteRemoteLogbook(id).catch((err) => {
-				console.log("Device offline. Deletion will need to be reconciled later.", err.message);
-			});
+			if (user?.id){
+				deleteRemoteLogbook(id).catch((err) => {
+					console.log("Device offline. Deletion will need to be reconciled later.", err.message);
+				});
+			}
 
 			return id;
 		},
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: LOGBOOK_KEYS.all });
+			queryClient.invalidateQueries({ queryKey: LOGBOOK_KEYS.all(ownerId) });
 		},
 	});
 }
@@ -64,24 +80,64 @@ export function useDeleteVessel() {
 export function useSyncVessels() {
 	const db = useSQLiteContext();
 	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
 
 	return useMutation({
 		mutationFn: async () => {
-			// Fetch remote DTOs
-			const remoteLogbooks = await fetchRemoteLogbooks();
+			// Manual syncing strictly requires an account
+			if (!user?.id) throw new Error("You must be logged in to sync with the server.");
 
-			// Execute local SQLite merge
-			await syncLogbooks(db, remoteLogbooks);
+			const remoteLogbooks = await fetchRemoteLogbooks();
+			await syncLogbooks(db, remoteLogbooks, user.id);
 
 			return remoteLogbooks.length;
 		},
 		onSuccess: (syncedCount) => {
-			// Force the UI to re-read from SQLite and update the vessel list
-			queryClient.invalidateQueries({ queryKey: LOGBOOK_KEYS.all });
+			queryClient.invalidateQueries({ queryKey: LOGBOOK_KEYS.all(user?.id || "local") });
 			Alert.alert("Sync Complete", `Successfully restored ${syncedCount} vessels from the server.`);
 		},
 		onError: (error: any) => {
 			Alert.alert("Sync Failed", error.message || "Could not reach the server.");
 		},
+	});
+}
+
+export function useMergeLocalData() {
+	const db = useSQLiteContext();
+	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
+
+	return useMutation({
+		mutationFn: async () => {
+			if (!user?.id) throw new Error("You must be logged in to link data.");
+
+			// Re-label local vessels to belong to the new user
+			const movedCount = await assignLocalDataToUser(db, user.id);
+
+			// Fetch these newly updated vessels from SQLite
+			const allMyVessels = await getLogbooks(db, user.id);
+
+			// Loop through + push them to the db
+			await Promise.all(allMyVessels.map(async (vessel) => {
+				try {
+					// Try to create it on the server
+					// If it already exists, server might return an error
+					await createRemoteLogbook(vessel.id, vessel.name, vessel.type || "", vessel.registration || "");
+				} catch (e) {
+					// Ignore "Already Exists" errors, strictly log others
+					console.log(`Sync push for ${vessel.name}:`, e);
+				}
+			}));
+
+			return movedCount;
+		},
+		onSuccess: (count) => {
+			// Refresh the UI to show the merged data
+			queryClient.invalidateQueries({ queryKey: LOGBOOK_KEYS.all(user?.id || "") });
+			Alert.alert("Success", `${count} offline vessels have been linked to your account and backed up!`);
+		},
+		onError: (err) => {
+			Alert.alert("Link Failed", "Could not link offline data: " + err.message);
+		}
 	});
 }

--- a/mobile/src/utils/api.ts
+++ b/mobile/src/utils/api.ts
@@ -102,9 +102,9 @@ export async function registerUser(email: string, username: string, password: st
 		}
 
 		// Extract authorization payload
-		const accessToken = json.data?.accessToken?.token;
-		const refreshToken = json.data?.refreshToken?.token;
-		const backendUserId = json.data?.user?.userId;
+		const accessToken = json.data?.accessToken?.token || json.data?.accessToken;
+		const refreshToken = json.data?.refreshToken?.token || json.data?.refreshToken;
+		const backendUserId = json.data?.user?.id || json.data?.user?.userId;
 
 		if (!accessToken || !backendUserId) {
 			throw new Error("Critical: Server did not return expected authentication payload.");

--- a/mobile/src/utils/api.ts
+++ b/mobile/src/utils/api.ts
@@ -1,41 +1,6 @@
 import { Platform } from "react-native";
 import * as SecureStore from "expo-secure-store";
-
-/**
- * This is only for prototyping and testing the login functionality
- * @param email Users email to login to the application
- * @param password Users password
- * @returns Either users username, or if credentials are invalid returns null
- */
-export async function loginUserOld(email: string, password: string): Promise<UserData | null> {
-	// Simulate a short network delay for realism
-	await new Promise((resolve) => setTimeout(resolve, 500));
-
-	if (email === "eikka@moikka.fi" && password === "moikka") {
-		return {
-			id: "mock-id-eikka",
-			name: "eikka",
-			email: "eikka@moikka.fi",
-		};
-	}
-
-	return null;
-}
-
-// This is only temporary for demonstration purposes
-export async function registerUserTemp(email: string, username: string, password: string): Promise<UserData | null> {
-	// Simulate a short network delay for realism during presentation
-	await new Promise((resolve) => setTimeout(resolve, 800));
-
-	console.log("Mock Registration initiated for:", { email, username });
-
-	// Return a success object immediately
-	return {
-		id: "temp-id-" + Math.floor(Math.random() * 10000),
-		name: username,
-		email: email,
-	};
-}
+import { DBLogItem } from "@/src/types/db";
 
 /**
  * Resolves the backend API base URL via Expo's build-time environment injection
@@ -286,4 +251,150 @@ export async function fetchRemoteLogbooks(): Promise<any[]> {
 
 	// Return the array of vessels mapped by the backend repository
 	return json.data;
+}
+
+// ------------------------------
+// --- Log item API functions ---
+// ------------------------------
+
+/**
+ * Pushes an array of locally created log items to the backend
+ * Uses POST to append new items to the remote db
+ */
+export async function pushRemoteLogItems(logbookId: string, localItems: DBLogItem[]): Promise<any> {
+	const headers = await getAuthHeader();
+
+	// Map the SQLite snake_case columns to the backend's expected camelCase JSON
+	const payload = localItems.map((item) => ({
+		id: item.id,
+		logbookId: logbookId,
+		title: item.title,
+		body: item.body ? item.body : undefined,
+		latitude: item.latitude,
+		longitude: item.longitude,
+		createdAt: item.created_at,
+		updatedAt: item.updated_at,
+		isActive: true, // New items are always active
+	}));
+
+	const response = await fetch(`${API_URL}/logbooks/${logbookId}/logs`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({ logitems: payload }),
+	});
+
+	const json = await response.json();
+	console.log("RAW SERVER POST RESPONSE:", JSON.stringify(json, null, 2));
+
+	if (!response.ok || json.success === false) {
+		throw new Error(json.error?.message || json.message || "Failed to push log items.");
+	}
+
+	return json.data;
+}
+
+/**
+ * Pushes edits of locally modified log items to the backend
+ * Uses PUT to update existing records in the remote db
+ */
+export async function updateRemoteLogItems(logbookId: string, localItems: DBLogItem[]): Promise<any> {
+	const headers = await getAuthHeader();
+
+	// Loop through the array and hit the singular PUT endpoint one by one
+	// to temporarily bypass the broken bulk-update backend route
+	for (const localItem of localItems) {
+		const payload = {
+			id: localItem.id,
+			logbookId: logbookId,
+			title: localItem.title,
+			body: localItem.body ? localItem.body : undefined,
+			latitude: localItem.latitude,
+			longitude: localItem.longitude,
+			createdAt: localItem.created_at,
+			updatedAt: localItem.updated_at,
+			isActive: true,
+		};
+
+		const response = await fetch(`${API_URL}/logbooks/${logbookId}/logs/${localItem.id}`, {
+			method: "PUT",
+			headers,
+			// The singular endpoint strictly expects the object to be wrapped in a "logitem" key
+			body: JSON.stringify({ logitem: payload }),
+		});
+
+		const json = await response.json();
+
+		if (!response.ok || json.success === false) {
+			throw new Error(json.error?.message || json.message || "Failed to update remote log item.");
+		}
+	}
+
+	return { success: true };
+	/*
+	const payload = localItems.map((item) => ({
+		id: item.id,
+		logbookId: logbookId,
+		title: item.title,
+		body: item.body ? item.body : undefined,
+		latitude: item.latitude,
+		longitude: item.longitude,
+		createdAt: item.created_at,
+		updatedAt: item.updated_at,
+		isActive: true,
+	}));
+
+	const response = await fetch(`${API_URL}/logbooks/${logbookId}/logs`, {
+		method: "PUT", // <--- THE CRITICAL DIFFERENCE
+		headers,
+		body: JSON.stringify({ logitems: payload }),
+	});
+
+	const json = await response.json();
+
+	if (!response.ok || json.success === false) {
+		throw new Error(json.error?.message || json.message || JSON.stringify(json));
+	}
+
+	return json.data;
+	 */
+}
+
+/**
+ * Tells the backend to mark specific log items as deleted
+ */
+export async function deleteRemoteLogItems(logbookId: string, itemIds: string[]): Promise<any> {
+	const headers = await getAuthHeader();
+
+	// Loop through the array and hit the singular delete endpoint one by one
+	// to temporarily bypass the broken bulk-delete backend route
+	for (const itemId of itemIds) {
+		const response = await fetch(`${API_URL}/logbooks/${logbookId}/logs/${itemId}`, {
+			method: "DELETE",
+			headers,
+		});
+
+		const json = await response.json();
+		if (!response.ok || json.success === false) {
+			throw new Error(json.error?.message || json.message || "Failed to delete remote log items.");
+		}
+	}
+
+	return { success: true };
+
+	/*
+	const headers = await getAuthHeader();
+
+	const response = await fetch(`${API_URL}/logbooks/${logbookId}/logs`, {
+		method: "DELETE",
+		headers,
+		body: JSON.stringify({ logitemIds: itemIds }),
+	});
+
+	const json = await response.json();
+	if (!response.ok || json.success === false) {
+		throw new Error(json.error?.message || json.message || "Failed to delete remote log items.");
+	}
+
+	return json.data;
+	 */
 }


### PR DESCRIPTION
implement multi-user data isolation + offline-to-online migration

Mobile:
- Implement client-side data isolation: Filter vessels by `owner_id` to separate Guest vs User data
- Add "Guest Mode": Offline users now create vessels under a "local" owner ID
- Add `useMergeLocalData`: Implements "Lazy Registration" allowing users to upload offline data to their new account
- Fix `logout` logic: Explicitly clears `currentLogbook` to prevent data leaks into Guest Mode
- UI: Replace delete button with "Long Press to Delete" gesture in Profile list
- UI: Add "Get vessels from phone" button for newly authenticated users

Database (SQLite):
- Schema: Enforce `owner_id` in `logbooks` table operations
- Migration: Add `assignLocalDataToUser` utility for account merging